### PR TITLE
Add Substack posts to blog with links

### DIFF
--- a/content/posts/modular-monoliths.en.md
+++ b/content/posts/modular-monoliths.en.md
@@ -1,0 +1,41 @@
++++
+title = "Modular Monoliths: The Architecture Pattern We Don't Talk Enough About"
+description = "Exploring modular monoliths, module communication, and interface placement strategies"
+tags = [
+    "architecture",
+    "python",
+    "backend",
+    "modular-monolith"
+]
+date = "2026-01-12"
+categories = [
+    "development"
+]
+author = "@__biancarosa"
++++
+
+*This post was originally published on my [Substack - Backend Engineering Adventures](https://backendengineeringadventures.substack.com/p/modular-monoliths-the-architecture).*
+
+We need to talk more about Modular Monoliths. Using a Python app as an example, this is just a way to organize folders, so it is a software architecture pattern that is transferable to many languages.
+
+## Module Communication
+
+The key to maintaining modularity is controlling how modules interact. Modules should communicate through service interfaces, not by directly importing each other's models or internals.
+
+## Two Approaches for Interface Placement
+
+1. **Routes within modules:** A particular module can have its own routes defined right in the module folder. If and when you break things into a new app, you just port it all into it, including API layers, and voila - you have a new service!
+
+2. **Framework-free modules:** For new apps where technical decisions are still being defined, keeping modules framework-free might be better. It allows flexibility to decide between framework/transport patterns of API layers when porting.
+
+## Framework Independence
+
+Keeping the modules framework-free means the service layer doesn't import Flask, FastAPI, or any web framework directly. Services return plain Python objects or raise regular exceptions, which the route layer then transforms into HTTP responses. This way, you can switch from Flask to FastAPI (or to a gRPC service) without touching your business logic.
+
+## Business Logic Placement
+
+Routes/controllers shouldn't have much business logic - all business logic should be in the service layers.
+
+---
+
+[Read the full post on Substack](https://backendengineeringadventures.substack.com/p/modular-monoliths-the-architecture)

--- a/content/posts/otel-honeycomb-alerts.en.md
+++ b/content/posts/otel-honeycomb-alerts.en.md
@@ -1,0 +1,42 @@
++++
+title = "OpenTelemetry, Python & Honeycomb: Setting Up Alerts"
+description = "How to configure meaningful alerts with OpenTelemetry and Honeycomb"
+tags = [
+    "opentelemetry",
+    "python",
+    "honeycomb",
+    "observability",
+    "backend"
+]
+date = "2025-06-09"
+categories = [
+    "development"
+]
+author = "@__biancarosa"
++++
+
+*This post was originally published on my [Substack - Backend Engineering Adventures](https://backendengineeringadventures.substack.com/p/opentelemetry-python-and-honeycomb).*
+
+This post follows my previous one about setting up OTEL in Python's API. Now let's focus on how to use this data we're sending to have useful alerts - not just dashboards, since no one wants to go insane refreshing them all the time.
+
+## Alerts in Honeycomb
+
+In Honeycomb, alerts are built around triggers - queries that run periodically and notify you when certain conditions are met. For example, monitoring HTTP 500 errors to catch issues in production.
+
+## Key Considerations
+
+Alert configuration involves two main aspects:
+- **Query Configuration:** Defining what you're monitoring
+- **Alert Thresholds:** When to trigger notifications
+
+These settings will likely need adjustment after initial setup. It requires knowing your system, trial and error, and observing historical patterns. Dynamic baselines can be extremely helpful if you know what you're doing.
+
+## Learning from False Positives
+
+After setting up alerts, my Slack channel got filled with notifications happening at least twice a day. However, the ratio of 500s to 200s wasn't significant. Deeper investigation of traces revealed the failures occurred due to errors querying the upstream API - something outside my control.
+
+The solution? Implement a 504 status code for upstream timeouts and exclude these from alerts. For more critical products, you might want to create a second, more specific alert like "we're receiving too many errors from the upstream API" rather than a generic "too many errors" alert.
+
+---
+
+[Read the full post on Substack](https://backendengineeringadventures.substack.com/p/opentelemetry-python-and-honeycomb)

--- a/content/posts/otel-honeycomb-getting-started.en.md
+++ b/content/posts/otel-honeycomb-getting-started.en.md
@@ -1,0 +1,53 @@
++++
+title = "Getting started with OTEL & Honeycomb in Python"
+description = "A practical guide to implementing OpenTelemetry with Honeycomb in Python applications"
+tags = [
+    "opentelemetry",
+    "python",
+    "honeycomb",
+    "observability",
+    "backend"
+]
+date = "2025-04-10"
+categories = [
+    "development"
+]
+author = "@__biancarosa"
++++
+
+*This post was originally published on my [Substack - Backend Engineering Adventures](https://backendengineeringadventures.substack.com/p/getting-started-with-otel-and-honeycomb).*
+
+I used OpenTelemetry in my "lastfm-last-played" project - a playground project serving a simple API that shows what music a user last played through last.fm. This was a great opportunity to explore OTEL outside of a work environment, which helps understand concepts better because the project is small and easy to understand.
+
+## Required Dependencies
+
+First, add the necessary packages to your pyproject.toml (or requirements.txt/Pipfile):
+- opentelemetry-api
+- opentelemetry-sdk
+- opentelemetry-instrumentation-flask
+- opentelemetry-instrumentation
+- opentelemetry-distro
+- opentelemetry-exporter-otlp
+
+## Auto-Instrumentation Setup
+
+The simplest way to implement OTEL is with auto-instrumentation. You set up environment variables like:
+- `OTEL_SERVICE_NAME`
+- `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`
+- `OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io`
+
+Then run with `opentelemetry-instrument`. This approach automatically instruments your application without requiring explicit code changes throughout your codebase.
+
+## API Key Configuration
+
+The last variable needed is `OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=<my-honeycomb-key>"`, which can be set in a .env file or directly on the shell (and in production app secrets).
+
+## Observability Tips
+
+Create meaningful spans: Break down complex operations into smaller spans to better understand where time is spent.
+
+The full pull request with the implementation lives here: https://github.com/biancarosa/lastfm-last-played/pull/34
+
+---
+
+[Read the full post on Substack](https://backendengineeringadventures.substack.com/p/getting-started-with-otel-and-honeycomb)

--- a/content/posts/trying-out-railway.en.md
+++ b/content/posts/trying-out-railway.en.md
@@ -1,0 +1,40 @@
++++
+title = "Trying out Railway - is it really good for backend systems?"
+description = "Initial thoughts on Railway platform after 2+ weeks of use"
+tags = [
+    "railway",
+    "deployment",
+    "backend",
+    "devops",
+    "platform"
+]
+date = "2025-01-25"
+categories = [
+    "development"
+]
+author = "@__biancarosa"
++++
+
+*This post was originally published on my [Substack - Backend Engineering Adventures](https://backendengineeringadventures.substack.com/p/trying-out-railway-is-it-really-good).*
+
+After using Railway for 2+ weeks, here are my initial thoughts on the platform. It's an incredible tool for small projects and prototypes with great potential.
+
+## What Shines
+
+Railway's deployment process is refreshingly simple - no YAML files to configure, no pipeline definitions to debug. It just... works. When issues occurred, it was usually due to my own Dockerfile not being tested locally before deploying.
+
+It easily supports cron-based dockerfiles - just give it a cron rule and a project and it'll run your container whenever needed.
+
+Adding a PostgreSQL database was equally painless. Railway's database provisioning is incredible. One of the most impressive features is Railway's approach to internal networking and variable sharing.
+
+## Areas Not Yet Tested
+
+- **Complex CI/CD requirements:** Like generating OpenAPI specs or triggering automation after deployments. I think I would build something webhook-based with Railway for those use cases.
+
+- **Custom build pipelines:** All my deploys were point-and-click setups where Railway handles docker builds and deploy.
+
+- **Heavy-load production scenarios:** It seems like it would handle things well with good modularization, but I need to see it working to be confident.
+
+---
+
+[Read the full post on Substack](https://backendengineeringadventures.substack.com/p/trying-out-railway-is-it-really-good)


### PR DESCRIPTION
Migrated 4 posts from Backend Engineering Adventures Substack:
- Modular Monoliths: The Architecture Pattern We Don't Talk Enough About
- OpenTelemetry, Python & Honeycomb: Setting Up Alerts
- Getting started with OTEL & Honeycomb in Python
- Trying out Railway - is it really good for backend systems?

Each post includes a link back to the original Substack article.