### PR TITLE
Move Substack embed to menu link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -67,6 +67,36 @@ googleAnalytics = "UA-44665454-3"
         name = "tech content recommendations"
         url = "/recommendations"
 
+      [[languages.en.menu.main]]
+        identifier = "linkedin"
+        name = "linkedin"
+        url = "https://www.linkedin.com/in/biarm"
+
+      [[languages.en.menu.main]]
+        identifier = "x"
+        name = "x"
+        url = "https://twitter.com/__biancarosa"
+
+      [[languages.en.menu.main]]
+        identifier = "github"
+        name = "github"
+        url = "https://github.com/biancarosa"
+
+      [[languages.en.menu.main]]
+        identifier = "bluesky"
+        name = "bluesky"
+        url = "https://bsky.app/profile/bianca-rosa.bsky.social"
+
+      [[languages.en.menu.main]]
+        identifier = "substack"
+        name = "substack"
+        url = "https://backendengineeringadventures.substack.com"
+
+      [[languages.en.menu.main]]
+        identifier = "fediverse"
+        name = "fediverse"
+        url = "https://hachyderm.io/@bia"
+
   [languages.pt]
     languageName = "português [brasil]"
     title = "biancarosa.com.br"
@@ -96,3 +126,33 @@ googleAnalytics = "UA-44665454-3"
         identifier = "aprenda-go"
         name = "aprendago.com.br"
         url = "https://aprendago.com.br"
+
+      [[languages.pt.menu.main]]
+        identifier = "linkedin"
+        name = "linkedin"
+        url = "https://www.linkedin.com/in/biarm"
+
+      [[languages.pt.menu.main]]
+        identifier = "x"
+        name = "x"
+        url = "https://twitter.com/__biancarosa"
+
+      [[languages.pt.menu.main]]
+        identifier = "github"
+        name = "github"
+        url = "https://github.com/biancarosa"
+
+      [[languages.pt.menu.main]]
+        identifier = "bluesky"
+        name = "bluesky"
+        url = "https://bsky.app/profile/bianca-rosa.bsky.social"
+
+      [[languages.pt.menu.main]]
+        identifier = "substack"
+        name = "substack"
+        url = "https://backendengineeringadventures.substack.com"
+
+      [[languages.pt.menu.main]]
+        identifier = "fediverse"
+        name = "fediverse"
+        url = "https://hachyderm.io/@bia"

--- a/layouts/partials/extended_header.html
+++ b/layouts/partials/extended_header.html
@@ -22,9 +22,6 @@
 <hr />
 
 {{ if .IsHome }}
-<h2>Substack (Posts Futuros / Future Posts)</h2>
-<iframe src="https://backendengineeringadventures.substack.com/embed" width="100%" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>
-
 <h2>Go Essentials & Descomplicando o Go</h2>
 <a href="https://linuxtips.io">Disponíveis na LinuxTips.io</a>
 {{ end }}


### PR DESCRIPTION
- Remove the embedded Substack iframe from the main page
- Add social media links to both EN and PT menus: LinkedIn, X, GitHub, Bluesky, Substack, Fediverse