### PR TITLE
Fix Firebase hosting deployment by adding site name

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,6 @@
 {
   "hosting": {
+    "site": "blog-da-bia",
     "public": "public",
     "ignore": [
       "firebase.json",


### PR DESCRIPTION
Add explicit site property to firebase.json to resolve the assertion error about missing site name or target name during deployment.