### PR TITLE
Reorder menu links and shorten text

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -147,11 +147,6 @@ theme = "terminal"
         url = "/talks"
 
       [[languages.pt.menu.main]]
-        identifier = "aprenda-go"
-        name = "aprendago.com.br"
-        url = "https://aprendago.com.br"
-
-      [[languages.pt.menu.main]]
         identifier = "linkedin"
         name = "linkedin"
         url = "https://www.linkedin.com/in/biarm"

--- a/config.toml
+++ b/config.toml
@@ -81,7 +81,7 @@ theme = "terminal"
 
       [[languages.en.menu.main]]
         identifier = "recommendations"
-        name = "tech content recommendations"
+        name = "recs"
         url = "/recommendations"
         weight = 4
 

--- a/config.toml
+++ b/config.toml
@@ -65,51 +65,61 @@ theme = "terminal"
         identifier = "about"
         name = "_self"
         url = "/about"
+        weight = 1
 
       [[languages.en.menu.main]]
         identifier = "blog-en"
         name = "blog"
         url = "/"
+        weight = 2
 
       [[languages.en.menu.main]]
         identifier = "talks"
         name = "talks"
         url = "/talks"
+        weight = 3
 
       [[languages.en.menu.main]]
         identifier = "recommendations"
         name = "tech content recommendations"
         url = "/recommendations"
+        weight = 4
 
       [[languages.en.menu.main]]
         identifier = "x"
         name = "x"
         url = "https://twitter.com/__biancarosa"
+        weight = 5
 
       [[languages.en.menu.main]]
         identifier = "bluesky"
         name = "bluesky"
         url = "https://bsky.app/profile/bianca-rosa.bsky.social"
+        weight = 6
 
       [[languages.en.menu.main]]
         identifier = "fediverse"
         name = "fediverse"
         url = "https://hachyderm.io/@bia"
+        weight = 7
 
       [[languages.en.menu.main]]
         identifier = "github"
         name = "github"
         url = "https://github.com/biancarosa"
+        weight = 8
 
       [[languages.en.menu.main]]
         identifier = "linkedin"
         name = "linkedin"
         url = "https://www.linkedin.com/in/biarm"
+        weight = 9
 
       [[languages.en.menu.main]]
         identifier = "substack"
         name = "substack"
         url = "https://backendengineeringadventures.substack.com"
+        weight = 10
 
   [languages.pt]
     languageName = "português [brasil]"

--- a/config.toml
+++ b/config.toml
@@ -62,18 +62,18 @@ theme = "terminal"
 
     [languages.en.menu]
       [[languages.en.menu.main]]
+        identifier = "about"
+        name = "_self"
+        url = "/about"
+
+      [[languages.en.menu.main]]
         identifier = "blog-en"
         name = "blog"
         url = "/"
 
       [[languages.en.menu.main]]
-        identifier = "about"
-        name = "about me"
-        url = "/about"
-
-      [[languages.en.menu.main]]
         identifier = "talks"
-        name = "talks & presentations"
+        name = "talks"
         url = "/talks"
 
       [[languages.en.menu.main]]
@@ -82,14 +82,14 @@ theme = "terminal"
         url = "/recommendations"
 
       [[languages.en.menu.main]]
-        identifier = "linkedin"
-        name = "linkedin"
-        url = "https://www.linkedin.com/in/biarm"
+        identifier = "bluesky"
+        name = "bluesky"
+        url = "https://bsky.app/profile/bianca-rosa.bsky.social"
 
       [[languages.en.menu.main]]
-        identifier = "x"
-        name = "x"
-        url = "https://twitter.com/__biancarosa"
+        identifier = "fediverse"
+        name = "fediverse"
+        url = "https://hachyderm.io/@bia"
 
       [[languages.en.menu.main]]
         identifier = "github"
@@ -97,9 +97,9 @@ theme = "terminal"
         url = "https://github.com/biancarosa"
 
       [[languages.en.menu.main]]
-        identifier = "bluesky"
-        name = "bluesky"
-        url = "https://bsky.app/profile/bianca-rosa.bsky.social"
+        identifier = "linkedin"
+        name = "linkedin"
+        url = "https://www.linkedin.com/in/biarm"
 
       [[languages.en.menu.main]]
         identifier = "substack"
@@ -107,9 +107,9 @@ theme = "terminal"
         url = "https://backendengineeringadventures.substack.com"
 
       [[languages.en.menu.main]]
-        identifier = "fediverse"
-        name = "fediverse"
-        url = "https://hachyderm.io/@bia"
+        identifier = "x"
+        name = "x"
+        url = "https://twitter.com/__biancarosa"
 
   [languages.pt]
     languageName = "português [brasil]"

--- a/config.toml
+++ b/config.toml
@@ -82,6 +82,11 @@ theme = "terminal"
         url = "/recommendations"
 
       [[languages.en.menu.main]]
+        identifier = "x"
+        name = "x"
+        url = "https://twitter.com/__biancarosa"
+
+      [[languages.en.menu.main]]
         identifier = "bluesky"
         name = "bluesky"
         url = "https://bsky.app/profile/bianca-rosa.bsky.social"
@@ -105,11 +110,6 @@ theme = "terminal"
         identifier = "substack"
         name = "substack"
         url = "https://backendengineeringadventures.substack.com"
-
-      [[languages.en.menu.main]]
-        identifier = "x"
-        name = "x"
-        url = "https://twitter.com/__biancarosa"
 
   [languages.pt]
     languageName = "português [brasil]"

--- a/content/recommendations.md
+++ b/content/recommendations.md
@@ -18,6 +18,7 @@ Staff Engineer: Leadership Beyond the Management Track](https://www.goodreads.co
 
 # Go
 
+- [aprendago.com.br](https://aprendago.com.br) - Go course in Portuguese
 - [Concurrency in Go: Tools and Techniques for Developers](https://www.goodreads.com/book/show/30413199-concurrency-in-go)
 - [The Go Programming Language](https://www.goodreads.com/book/show/25080953-the-go-programming-language)
 


### PR DESCRIPTION
- Rename "about me" to "_self"
- Rename "talks & presentations" to "talks"
- Group content pages first, then social media links together